### PR TITLE
Fix obvious typos in links to docs and GH

### DIFF
--- a/_software/metanorma-ietf.adoc
+++ b/_software/metanorma-ietf.adoc
@@ -4,8 +4,8 @@ repo_url: https://github.com/riboseinc/metanorma-ietf
 description: Processor producing RFC XML v3 (RFC 7991) and v2 (RFC 7749).
 
 external_links:
-  - { url: /author/iotf/, title: "Author’s docs" }
-  - url: https://github.com/riboseinc/metanorma-iotf
+  - { url: /author/ietf/, title: "Author’s docs" }
+  - url: https://github.com/riboseinc/metanorma-ietf
   - url: https://rubygems.org/gems/metanorma-ietf
 
 tags: ["writtenin:Ruby", "user:standardization_bodies", "user:IETF", "Metanorma_flavor"]


### PR DESCRIPTION
It's IETF, not IOTF.  Links were invalid (HTTP 404) for this reason.