### PR TITLE
Update `++++` markup to make it render properly

### DIFF
--- a/author/topics/document-format/text.adoc
+++ b/author/topics/document-format/text.adoc
@@ -303,16 +303,16 @@ Metanorma AsciiDoc accepts mathematical input in either
 LaTeX math or AsciiMath, with the following conventions:
 
 * The document attribute `:stem:` means any markup tagged as `[stem]`
-(`stem:[...]`, or `[stem]` before a block delimited with `++++`)
+(`stem:[...]`, or `[stem]` before a block delimited with `\++++{blank}`)
 is interpreted as AsciiMath.
 * The document attribute `:stem: latexmath` means any markup tagged as `[stem]`
-(`stem:[...]`, or `[stem]` before a block delimited with `++++`)
+(`stem:[...]`, or `[stem]` before a block delimited with `\++++{blank}`)
 is interpreted as LaTeX.
 * Any markup tagged as `[asciimath]`
-(`asciimath:[...]`, or `[asciimath]` before a block delimited with `++++`)
+(`asciimath:[...]`, or `[asciimath]` before a block delimited with `\++++{blank}`)
 is interpreted as AsciiMath.
 * Any markup tagged as `[latexmath]`
-(`latexmath:[...]`, or `[latexmath]` before a block delimited with `++++`)
+(`latexmath:[...]`, or `[latexmath]` before a block delimited with `\++++{blank}`)
 is interpreted as LaTeX.
 
 Any Unicode characters in the LaTeX source are translated into LaTeX escapes,


### PR DESCRIPTION
Looking at [Math Expressions](https://www.metanorma.com/author/topics/document-format/text/#mathematical-expressions), this markup: `++++` renders empty (` `).
So, after a couple of iterations, I've confirmed that if we encoded it like: `\++++{blank}` , it would render as expected (in normal Asciidoc).