### PR TITLE
Add escaping character "\" to "stem[]", "asciimath:[]", and "latexmath:[]"

### DIFF
--- a/author/topics/document-format/text.adoc
+++ b/author/topics/document-format/text.adoc
@@ -309,17 +309,17 @@ Metanorma AsciiDoc accepts mathematical input in these formats:
 
 Math can be entered using one of the following mechanisms:
 
-* the `stem:[...]`, `asciimath:[]` and the `latexmath:[]` commands; and
+* the `\stem:[...]`, `\asciimath:[]` and the `latexmath:[]` commands; and
 * the `[stem]`, `[asciimath]`, `[latexmath]` blocks delimited with `\++++{blank}`
 
-The math syntax used by `stem:[...]` and `[stem]` blocks depends on
+The math syntax used by `\stem:[...]` and `[stem]` blocks depends on
 the value of the document attribute `:stem:`. It accepts these values:
 
 `latexmath`:: any markup within `stem` is interpreted as LaTeX math
 `asciimath`:: any markup within `stem` is interpreted as AsciiMath
 ``:: when left empty, AsciiMath is selected
 
-`stem:[...]` and `[stem]` markup that contains MathML markup
+`\stem:[...]` and `[stem]` markup that contains MathML markup
 (as detected by an initial `<math ... >`) is interpreted as MathML.
 
 MathML is used as the internal representation of STEM expressions in Metanorma.
@@ -327,9 +327,9 @@ MathML is used as the internal representation of STEM expressions in Metanorma.
 
 === Using AsciiMath
 
-AsciiMath can be entered using the `asciimath:[]` command and the
+AsciiMath can be entered using the `\asciimath:[]` command and the
 `[asciimath]` block delimited with `\++++{blank}`.
-The `stem:[]` and `[stem]` blocks can also be used if the document attribute
+The `\stem:[]` and `[stem]` blocks can also be used if the document attribute
 `:stem: asciimath` has been specified in the document.
 
 AsciiMath is converted into MathML using the
@@ -366,9 +366,9 @@ case it is necessary to use LaTeX math or MathML input.
 
 === Using LaTeX math
 
-LaTeX math can be entered using the `latexmath:[]` command and the
+LaTeX math can be entered using the `\latexmath:[]` command and the
 `[latexmath]` block delimited with `\++++{blank}`.
-The `stem:[]` and `[stem]` blocks can also be used if the document attribute
+The `\stem:[]` and `[stem]` blocks can also be used if the document attribute
 `:stem: latexmath` has been specified in the document.
 
 LaTeX math is converted into MathML using the


### PR DESCRIPTION
Currently, in [Mathematical expressions](https://www.metanorma.com/author/topics/document-format/text/#mathematical-expressions) section, code parts like:

````
Math can be entered using one of the following mechanisms:

* the `stem:[...]`, `asciimath:[]` and the `latexmath:[]` commands; and
* the `[stem]`, `[asciimath]`, `[latexmath]` blocks delimited with `\++++{blank}`
````
renders as

![Capture](https://user-images.githubusercontent.com/33627611/84618964-ba7ddd80-aea1-11ea-8705-d95adb58d3d4.PNG)

So, there are segments that need to be escaped. For instance, `stem:[...]` as `\stem:[...]`, and `latexmath:[]` as `\latexmath:[]`.

This PR is for that.

Thanks!
