### PR TITLE
differentiate Symbols and Abbreviated Terms as clause types: https://…

### DIFF
--- a/author/topics/document-format/sections.adoc
+++ b/author/topics/document-format/sections.adoc
@@ -24,7 +24,9 @@ to identify the different kinds of sections in the document, namely these:
 * `Scope`
 * `Normative references`
 * `Terms and definitions`
-* `Symbols and abbreviations`
+* `Symbols and abbreviated terms`
+* `Symbols` [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v1.5.0]
+* `Abbreviated terms` [added in https://github.com/metanorma/metanorma-standoc/releases/tag/v1.5.0]
 * `Bibliography`
 
 [NOTE]


### PR DESCRIPTION
…github.com/metanorma/isodoc/issues/171

The distinction between Symbols and Abbreviated Terms will be introduced in standoc v1.5.0, i.e. when the pres_xml branch will be merged in.