### PR TITLE
Add ITU `resolution` doctype to the list of choices

### DIFF
--- a/author/itu/authoring.adoc
+++ b/author/itu/authoring.adoc
@@ -33,6 +33,7 @@ Document type. Choices:
 * `technical-paper`: This document is a ITU Technical Paper.
 * `technical-report`: This document is a ITU Technical Report.
 * `joint-itu-iso-iec`: This document is a "`Common Text`" Recommendation between ITU and ISO/IEC JTC 1.
+* `resolution`: This document is an ITU Resolution.
 --
 
 `:status:`::

--- a/author/itu/authoring.adoc
+++ b/author/itu/authoring.adoc
@@ -30,8 +30,8 @@ Document type. Choices:
 * `recommendation-annex`: This document is an Annex of an ITU Recommendation.
 * `focus-group`: This document is the output of a Focus Group.
 * `implementers-guide`: This document is an ITU Implementers Guide.
-* `technical-paper`: This document is a ITU Technical Paper.
-* `technical-report`: This document is a ITU Technical Report.
+* `technical-paper`: This document is an ITU Technical Paper.
+* `technical-report`: This document is an ITU Technical Report.
 * `joint-itu-iso-iec`: This document is a "`Common Text`" Recommendation between ITU and ISO/IEC JTC 1.
 * `resolution`: This document is an ITU Resolution.
 --


### PR DESCRIPTION
*In relation to this question https://github.com/metanorma/metanorma-itu/issues/211*
*I have received email notification that the **build site** was failed. I only made a minor change in an adoc file though. So I decided to open the PR anyway.*

The `resolution` document type is missing in the list of choices of ITU authoring. I have added it.
