### PR TITLE
Fix minor typos

### DIFF
--- a/author/gb/topics/output-formats.adoc
+++ b/author/gb/topics/output-formats.adoc
@@ -14,7 +14,7 @@ using Metanorma AsciiDoc formatting.
 ** http://asciimath.org[AsciiMathML] is to be used for mathematical formatting.
 Metanorma-GB uses the https://github.com/asciidoctor/asciimath[Ruby AsciiMath parser],
 which is syntactically stricter than the common MathJax processor;
-if you do not get expected results, try bracketing terms your in AsciiMathML
+if you do not get expected results, try bracketing terms in your AsciiMathML
 expressions.
 * an XML representation of the document, intended as a document model for GB
 International Standards.

--- a/author/ietf/ref/document-attributes-v2.adoc
+++ b/author/ietf/ref/document-attributes-v2.adoc
@@ -71,7 +71,7 @@ Metanorma-IETF allows setting the RFC XML document header using the following
 document attributes. Complying with AsciiDoc syntax, no blank lines are
 permitted between the title, listing of authors, and the document attributes.
 Also following AsciiDoc syntax, character entities will be ignored in the document
-header: `&nbsp;` in the header for example will be rendered as `&amp;nbsp;`.
+header: `\&nbsp;` in the header for example will be rendered as `&amp;nbsp;`.
 
 NOTE: Most attributes listed here, unless specifically stated, are common between
 AsciiRFC v3 (RFC XML v3) and AsciiRFC v2 (RFC XML v2).

--- a/author/ietf/ref/document-attributes.adoc
+++ b/author/ietf/ref/document-attributes.adoc
@@ -75,7 +75,7 @@ document attributes. Complying with AsciiDoc syntax, no blank lines are
 permitted between the title, listing of authors, and the document attributes.
 
 Also following AsciiDoc syntax, character entities will be ignored in the document
-header: `&nbsp;` in the header for example will be rendered as `&amp;nbsp;`.
+header: `\&nbsp;` in the header for example will be rendered as `&amp;nbsp;`.
 
 NOTE: Most attributes listed here, unless specifically stated, are common between
 AsciiRFC v3 (RFC XML v3) and AsciiRFC v2 (RFC XML v2).

--- a/author/ietf/topics/references.adoc
+++ b/author/ietf/topics/references.adoc
@@ -21,10 +21,10 @@ anchors and identifiers in a bibliographic entry list. If the identifier is reco
 with online data (including IETF standards), the bibliographic data for that identifier is fetched,
 cached locally, and inserted into the Metanorma XML.
 
-So for example `* [[[RFC7152,RFC 7152]]]` will be
+So for example `* [\[[RFC7152,RFC 7152]]]` will be
 recognised as a citation of RFC 7152, and the corresponding bibliographic data will be fetched from the
 corresponding online source. However, that data will be fetched not in its native RFC XML, but in Relaton
-XML, as with the rest of Metanorma; a reference to `* [[[ISO639-2,ISO 639-2]]]` would not be treated any
+XML, as with the rest of Metanorma; a reference to `* [\[[ISO639-2,ISO 639-2]]]` would not be treated any
 differently.
 
 That said, any references recognised as being to IETF standards will include the URI for their RFC XML source,

--- a/author/topics/document-format/bibliography.adoc
+++ b/author/topics/document-format/bibliography.adoc
@@ -18,7 +18,7 @@ Every bibliographic section must be preceded by the style attribute
 == Bibliography
 
 * [[[id1,1]]] _First reference_
-* [[[id1,2]]] _Second reference_
+* [[[id2,2]]] _Second reference_
 * [[[id3,3]]] _Third reference_
 --
 


### PR DESCRIPTION
Actions taken:

* In [Document attributes (AsciiRFC v3)](https://www.metanorma.com/author/ietf/ref/document-attributes/) there is a paragraph:
````
So for example `* [[[RFC7152,RFC 7152]]]` will be
recognised as a citation of RFC 7152, and the corresponding bibliographic data will be fetched from the
corresponding online source. However, that data will be fetched not in its native RFC XML, but in Relaton
XML, as with the rest of Metanorma; a reference to `* [[[ISO639-2,ISO 639-2]]]` would not be treated any
differently.
````

that renders like:

![refs-text](https://user-images.githubusercontent.com/33627611/91886589-8a033f80-ec57-11ea-9f11-63fceaadd082.PNG)

It is necessary to insert an escape character (`\`) in order to show the text properly: `* [\[[RFC7152,RFC 7152]]]`
I found a few cases like this one and fixed them.

* Fix two minor typos.