### PR TITLE
Fix ribose bar menu links

### DIFF
--- a/_layouts/ribose-flavor.adoc
+++ b/_layouts/ribose-flavor.adoc
@@ -17,7 +17,7 @@ ribose_flavor:
     - path: ./authoring/
       title: guide
 
-base_url: /author/rsd
+base_url: /author/ribose
 
 navigation:
   items:

--- a/author/m3aawg/authoring.adoc
+++ b/author/m3aawg/authoring.adoc
@@ -16,7 +16,7 @@ For _common document attributes_, see link:/author/ref/document-attributes/[Docu
 For an _introduction to Metanorma AsciiDoc document attributes_ and how Metanorma uses them, see link:/author/topics/document-format/meta-attributes/[the corresponding topic].
 ====
 
-`:status:``:: The document status. Synonym: `:docstage:`.
+`:status:`:: The document status. Synonym: `:docstage:`.
 The permitted types are: `proposal`,
 `working-draft`, `committee-draft`, `draft-standard`, `final-draft`,
 `published`, `withdrawn`.


### PR DESCRIPTION
*As requested in https://github.com/metanorma/metanorma-ribose/issues/69 (I believe)*

Currently, the links of the bar menu in [Metanorma for Ribose](https://www.metanorma.com/author/ribose) are leading to 404 page. This because they are using `author/rsd` as base url instead of `author/ribose`. This PR corrects that.
