### PR TITLE
Update yaml2text documentation (blog post and yaml2text documentation)

### DIFF
--- a/_posts/2020-05-07-using-yaml-as-data-source.adoc
+++ b/_posts/2020-05-07-using-yaml-as-data-source.adoc
@@ -67,6 +67,7 @@ Next, we'll see how various YAML data structures can be represented:
 * <<array-of-interpolated-files,interpolate file names for AsciiDoc `include`>>
 * <<array-of-objects,array of objects>>
 
+yaml2text also supports basic liquid tags and expressions, see  <<liquid-code-snippets, liquid code snippets>>
 
 [[simple-object]]
 == Accessing object properties
@@ -481,6 +482,51 @@ You might also have noticed that one can do simple arithmetics in
 interpolations and array indexing, like `{num.# + 1}` and `{ar[num.# - 1]}` in
 the example above.
 
+
+--
+
+
+[[liquid-code-snippets]]
+== Liquid code snippets
+
+`yaml2text` can use basic Liquid expressions and tags.
+
+EXAMPLE:
+--
+Given:
+
+example.yml
+[source,yaml]
+----
+---
+- name: One
+  show: true
+- name: Two
+  show: true
+- name: Three
+  show: false
+----
+
+And the block:
+[source,asciidoc]
+--------
+[yaml2text,example.yml,my_context]
+----
+{% for item in my_context %}
+{% if item.show %}
+{{ item.name | upcase }}
+{{ item.name | size }}
+{% endif %}
+{% endfor %}
+----
+--------
+
+Will render as:
+[source,asciidoc]
+------
+ONE 3
+TWO 3
+------
 
 --
 

--- a/_posts/2020-05-07-using-yaml-as-data-source.adoc
+++ b/_posts/2020-05-07-using-yaml-as-data-source.adoc
@@ -41,7 +41,7 @@ the specified YAML file.
 ----
 This template will be rendered as AsciiDoc content. <2>
 
-{... my_yaml_context ...} <3>
+{{... my_yaml_context ...}} <3>
 ----
 -----
 
@@ -52,7 +52,7 @@ is relative to the directory of the AsciiDoc file defining the block.
 <2> The template is whatever that goes inside the block.
 
 <3> Content from the YAML file is interpolated via the context name, surrounded
-by curly braces.
+by double curly braces.
 
 That's the gist of it.
 
@@ -89,7 +89,7 @@ The following block...
 ------
 [yaml2text,strings.yaml,data]
 ----
-I'm heading to the {data.foo} for {data.dead}.
+I'm heading to the {{data.foo}} for {{data.dead}}.
 ----
 ------
 
@@ -127,7 +127,7 @@ The following block...
 ------
 [yaml2text,array.yml,data]
 ----
-The length of the YAML array is {data.*}.
+The length of the YAML array is {{data.size}}.
 ----
 ------
 
@@ -137,7 +137,7 @@ The length of the YAML array is {data.*}.
 The length of the YAML array is 3.
 ----
 
-`{data.*}` evaluates to the length of the array.
+`{{data.size}}` evaluates to the length of the array.
 
 --
 
@@ -163,12 +163,12 @@ The following block...
 ------
 [yaml2text,strings.yaml,arr]
 ----
-{arr.*,item,EOS}
-=== {item.#} {item}
+{% for item in arr %}
+=== {{forloop.index0}} {{item}}
 
-This section is about {item}.
+This section is about {{item}}.
 
-{EOS}
+{% endfor %}
 ----
 ------
 
@@ -189,18 +189,15 @@ This section is about dolor.
 ----
 
 
-Here, the expression `{arr.*,item,EOS}` tells the template engine to define a
+Here, the expression `{% for item in arr %}` tells the template engine to define a
 new context, `item`, to represent each individual item from the array `arr`.
 The context `item` is accessible (=== is under scope) within the lines between this
-expression and the first occurrence of `{EOS}`.
-
-`EOS` is just an example --- it can be anything (any alphanum) --- as long as
-it is unique for each intended scope for the context `item`.
+expression and the first occurrence of `{% endfor %}`.
 
 This template is then concatenated for each array item, in the original order
 of the array, as one might reasonably expect.
 
-`{item.#}` gives the zero-based position of item `item` in the parent array
+`{{forloop.index0}}` gives the zero-based position of item `item` in the parent array
 `arr`.
 
 
@@ -234,9 +231,9 @@ The following block...
 ------
 [yaml2text,object.yaml,data]
 ----
-=== {data.name}
+=== {{data.name}}
 
-{data.desc} {data.*}
+{{data.desc}} {{data.size}}
 ----
 ------
 
@@ -248,7 +245,7 @@ The following block...
 dolor sit amet 2
 ----
 
-If `data` represents a YAML object, then `{data.*}` gives you the number of
+If `data` represents a YAML object, then `{{data.size}}` gives you the number of
 key-value pairs in that object.
 
 
@@ -275,12 +272,12 @@ The following block...
 ------
 [yaml2text,object.yaml,my_item]
 ----
-{my_item.*,key,EOI}
-=== {key}
+{% for item in my_item %}
+=== {{item[0]}}
 
-{my_item[key]}
+{{item[1]}}
 
-{EOI}
+{% endfor %}
 ----
 ------
 
@@ -296,9 +293,9 @@ Lorem ipsum
 dolor sit amet
 ----
 
-`key` gives the key of each key-value pair of the object `my_item`.
+`item[0]` gives the key of each key-value pair of the object `my_item`.
 
-Like in common programming languages, `my_item[key]` gives the value corresponding to the key `key`.
+`item[1]` gives the value corresponding to the current iteration.
 
 --
 
@@ -322,13 +319,12 @@ The following block...
 ------
 [yaml2text,object.yaml,item]
 ----
-.{item.values[1]}
+.{{item.values[1]}}
 [%noheader,cols="h,1"]
 |===
-{item.*,key,EOK}
-| {key} | {item[key]}
-
-{EOK}
+{% for elem in item %}
+| {{elem[0]}} | {{elem[1]}}
+{% endfor %}
 |===
 ----
 ------
@@ -375,12 +371,13 @@ The following block...
 --------
 [yaml2text,strings.yaml,yaml]
 ------
+{% for item in yml.items %}
 [source,ruby]
 ----
-\include::{yaml.prefix}{s.#}.rb[]
+\include::{{yaml.prefix}}{{forloop.index0}}.rb[]
 ----
 
-{EOS}
+{% enfor %}
 ------
 --------
 
@@ -434,18 +431,18 @@ The following block...
 ------
 [yaml2text,array_of_objects.yaml,ar]
 ----
-First array item of last array item is {ar[-1].nums[0]}.
-Last array item of first array item is {ar[0].nums[-1]}.
+First array item of last array item is {{ar[-1].nums[0]}}.
+Last array item of first array item is {{ar[0].nums[-1]}}.
 
-{ar.*,item,EOF}
+{% for item in ar %}
 
 {item.name}:: {item.desc}
 
-{item.nums.*,num,EON}
-- {item.name}: index = {num.#}, index+1 = {num.# + 1},
-  {num} === {ar[num.#]}, prev = {ar[num.# - 1]}
-{EON}
-{EOF}
+{% for num in item.nums %}
+- {{item.name}}: index = {{forloop.index0}}, index+1 = {{forloop.index0 | plus: 1 }},
+  {{num}} === {{ar[forloop.index0]}}, prev = {% capture prev_index %}{{forloop.index0 | minus: 1}}{% endcapture %}{{ar[prev_index]}}
+{% endfor %}
+{% endfor %}
 ----
 ------
 
@@ -475,60 +472,13 @@ amet:: lorem
   6 === 6, prev = 2
 ----
 
-Notice the various contexts and their corresponding scope delimiters (`EOF` for
-`item`, `EON` for `num`).
-
-You might also have noticed that one can do simple arithmetics in
-interpolations and array indexing, like `{num.# + 1}` and `{ar[num.# - 1]}` in
+You might also have noticed that one can use liquid math filters in order to do simple arithmetics in
+interpolations and array indexing, like `{{forloop.index0 | plus: 1 }}` and `{{forloop.index0 | minus: 1}}` in
 the example above.
 
 
 --
 
-
-[[liquid-code-snippets]]
-== Liquid code snippets
-
-`yaml2text` can use basic Liquid expressions and tags.
-
-EXAMPLE:
---
-Given:
-
-example.yml
-[source,yaml]
-----
----
-- name: One
-  show: true
-- name: Two
-  show: true
-- name: Three
-  show: false
-----
-
-And the block:
-[source,asciidoc]
---------
-[yaml2text,example.yml,my_context]
-----
-{% for item in my_context %}
-{% if item.show %}
-{{ item.name | upcase }}
-{{ item.name | size }}
-{% endif %}
-{% endfor %}
-----
---------
-
-Will render as:
-[source,asciidoc]
-------
-ONE 3
-TWO 3
-------
-
---
 
 == Ending notes
 

--- a/_posts/2020-05-07-using-yaml-as-data-source.adoc
+++ b/_posts/2020-05-07-using-yaml-as-data-source.adoc
@@ -17,7 +17,7 @@ excerpt: >-
 
 NOTE: (UPDATED 2020-09-21) This blog post demonstrates the deprecated
 Yaml2Text syntax. Please refer to
-link:/blog/2020-09-20-using-yaml-as-data-source[the revised post] for the
+link:/blog/2020-09-20-yaml2text-supports-yaml-with-liquid[the revised post] for the
 updated Yaml2Text syntax.
 
 == Introduction

--- a/_posts/2020-09-20-yaml2text-supports-yaml-with-liquid.adoc
+++ b/_posts/2020-09-20-yaml2text-supports-yaml-with-liquid.adoc
@@ -44,6 +44,8 @@ the newly implemented template mini-language.
 
 In this blog post, we'll see how this is done.
 
+See the link:/author/topics/automation/yaml_to_text[Yaml2Text] page for more details!
+
 
 == Meet the updated yaml2text block
 

--- a/_posts/2020-09-20-yaml2text-supports-yaml-with-liquid.adoc
+++ b/_posts/2020-09-20-yaml2text-supports-yaml-with-liquid.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: "Using YAML as data source"
-date: 2020-05-07
+title: "Yaml2Text now supports YAML with Liquid"
+date: 2020-09-20
 categories: about
 authors:
   -
@@ -10,17 +10,26 @@ authors:
     social_links:
       - https://www.linkedin.com/in/jtklau/
       - https://github.com/ribose-jeffreylau
+  -
+    name: Mikhail Tretiakov
+    email: taraskinm@yandex.ru
+    social_links:
+      - https://github.com/w00lf
 
 excerpt: >-
-    Import YAML data into Metanorma has never been so easy
+    Importing YAML data into Metanorma using Liquid!
 ---
 
-NOTE: (UPDATED 2020-09-21) This blog post demonstrates the deprecated
-Yaml2Text syntax. Please refer to
-link:/blog/2020-09-20-using-yaml-as-data-source[the revised post] for the
-updated Yaml2Text syntax.
+== Introduction, redux!
 
-== Introduction
+Yaml2Text has been updated to support the popular Liquid syntax for
+accessing YAML data in `metanorma-standoc` version 1.5.3.
+
+NOTE: This is an updated version of the original blog post
+located link:/blog/2020-05-07-using-yaml-as-data-source[here].
+This new post represents the updated Yaml2Text block that uses
+https://shopify.github.io/liquid/[Liquid syntax]. Please
+see the original blog post to refer to the old syntax (metanorma-standoc <= v1.5.3).
 
 When authoring technical documents, there is often a need to represent
 structured data one way or the other.
@@ -35,7 +44,8 @@ the newly implemented template mini-language.
 
 In this blog post, we'll see how this is done.
 
-== Meet the yaml2text block
+
+== Meet the updated yaml2text block
 
 The `yaml2text` block defines a template, and the template gets its data from
 the specified YAML file.
@@ -46,7 +56,7 @@ the specified YAML file.
 ----
 This template will be rendered as AsciiDoc content. <2>
 
-{... my_yaml_context ...} <3>
+{{... my_yaml_context ...}} <3>
 ----
 -----
 
@@ -57,7 +67,7 @@ is relative to the directory of the AsciiDoc file defining the block.
 <2> The template is whatever that goes inside the block.
 
 <3> Content from the YAML file is interpolated via the context name, surrounded
-by curly braces.
+by double curly braces.
 
 That's the gist of it.
 
@@ -71,6 +81,9 @@ Next, we'll see how various YAML data structures can be represented:
 * <<keys-values-attributes,enumerating object items using `.keys` and `.values`>>
 * <<array-of-interpolated-files,interpolate file names for AsciiDoc `include`>>
 * <<array-of-objects,array of objects>>
+
+The `yaml2text` plugin also supports basic Liquid tags and expressions,
+see  <<liquid-code-snippets,Liquid code snippets>>
 
 
 [[simple-object]]
@@ -93,7 +106,7 @@ The following block...
 ------
 [yaml2text,strings.yaml,data]
 ----
-I'm heading to the {data.foo} for {data.dead}.
+I'm heading to the {{data.foo}} for {{data.dead}}.
 ----
 ------
 
@@ -131,7 +144,7 @@ The following block...
 ------
 [yaml2text,array.yml,data]
 ----
-The length of the YAML array is {data.*}.
+The length of the YAML array is {{data.size}}.
 ----
 ------
 
@@ -141,7 +154,7 @@ The length of the YAML array is {data.*}.
 The length of the YAML array is 3.
 ----
 
-`{data.*}` evaluates to the length of the array.
+`{{data.size}}` evaluates to the length of the array.
 
 --
 
@@ -167,12 +180,12 @@ The following block...
 ------
 [yaml2text,strings.yaml,arr]
 ----
-{arr.*,item,EOS}
-=== {item.#} {item}
+{% for item in arr %}
+=== {{forloop.index0}} {{item}}
 
-This section is about {item}.
+This section is about {{item}}.
 
-{EOS}
+{% endfor %}
 ----
 ------
 
@@ -193,18 +206,15 @@ This section is about dolor.
 ----
 
 
-Here, the expression `{arr.*,item,EOS}` tells the template engine to define a
+Here, the expression `{% for item in arr %}` tells the template engine to define a
 new context, `item`, to represent each individual item from the array `arr`.
 The context `item` is accessible (=== is under scope) within the lines between this
-expression and the first occurrence of `{EOS}`.
-
-`EOS` is just an example --- it can be anything (any alphanum) --- as long as
-it is unique for each intended scope for the context `item`.
+expression and the first occurrence of `{% endfor %}`.
 
 This template is then concatenated for each array item, in the original order
 of the array, as one might reasonably expect.
 
-`{item.#}` gives the zero-based position of item `item` in the parent array
+`{{forloop.index0}}` gives the zero-based position of item `item` in the parent array
 `arr`.
 
 
@@ -238,9 +248,9 @@ The following block...
 ------
 [yaml2text,object.yaml,data]
 ----
-=== {data.name}
+=== {{data.name}}
 
-{data.desc} {data.*}
+{{data.desc}} {{data.size}}
 ----
 ------
 
@@ -252,7 +262,7 @@ The following block...
 dolor sit amet 2
 ----
 
-If `data` represents a YAML object, then `{data.*}` gives you the number of
+If `data` represents a YAML object, then `{{data.size}}` gives you the number of
 key-value pairs in that object.
 
 
@@ -279,12 +289,12 @@ The following block...
 ------
 [yaml2text,object.yaml,my_item]
 ----
-{my_item.*,key,EOI}
-=== {key}
+{% for item in my_item %}
+=== {{item[0]}}
 
-{my_item[key]}
+{{item[1]}}
 
-{EOI}
+{% endfor %}
 ----
 ------
 
@@ -300,9 +310,9 @@ Lorem ipsum
 dolor sit amet
 ----
 
-`key` gives the key of each key-value pair of the object `my_item`.
+`item[0]` gives the key of each key-value pair of the object `my_item`.
 
-Like in common programming languages, `my_item[key]` gives the value corresponding to the key `key`.
+`item[1]` gives the value corresponding to the current iteration.
 
 --
 
@@ -326,13 +336,12 @@ The following block...
 ------
 [yaml2text,object.yaml,item]
 ----
-.{item.values[1]}
+.{{item.values[1]}}
 [%noheader,cols="h,1"]
 |===
-{item.*,key,EOK}
-| {key} | {item[key]}
-
-{EOK}
+{% for elem in item %}
+| {{elem[0]}} | {{elem[1]}}
+{% endfor %}
 |===
 ----
 ------
@@ -379,12 +388,13 @@ The following block...
 --------
 [yaml2text,strings.yaml,yaml]
 ------
+{% for item in yml.items %}
 [source,ruby]
 ----
-\include::{yaml.prefix}{s.#}.rb[]
+\include::{{yaml.prefix}}{{forloop.index0}}.rb[]
 ----
 
-{EOS}
+{% enfor %}
 ------
 --------
 
@@ -438,18 +448,18 @@ The following block...
 ------
 [yaml2text,array_of_objects.yaml,ar]
 ----
-First array item of last array item is {ar[-1].nums[0]}.
-Last array item of first array item is {ar[0].nums[-1]}.
+First array item of last array item is {{ar[-1].nums[0]}}.
+Last array item of first array item is {{ar[0].nums[-1]}}.
 
-{ar.*,item,EOF}
+{% for item in ar %}
 
 {item.name}:: {item.desc}
 
-{item.nums.*,num,EON}
-- {item.name}: index = {num.#}, index+1 = {num.# + 1},
-  {num} === {ar[num.#]}, prev = {ar[num.# - 1]}
-{EON}
-{EOF}
+{% for num in item.nums %}
+- {{item.name}}: index = {{forloop.index0}}, index+1 = {{forloop.index0 | plus: 1 }},
+  {{num}} === {{ar[forloop.index0]}}, prev = {% capture prev_index %}{{forloop.index0 | minus: 1}}{% endcapture %}{{ar[prev_index]}}
+{% endfor %}
+{% endfor %}
 ----
 ------
 
@@ -479,15 +489,13 @@ amet:: lorem
   6 === 6, prev = 2
 ----
 
-Notice the various contexts and their corresponding scope delimiters (`EOF` for
-`item`, `EON` for `num`).
-
-You might also have noticed that one can do simple arithmetics in
-interpolations and array indexing, like `{num.# + 1}` and `{ar[num.# - 1]}` in
+You might also have noticed that one can use liquid math filters in order to do simple arithmetics in
+interpolations and array indexing, like `{{forloop.index0 | plus: 1 }}` and `{{forloop.index0 | minus: 1}}` in
 the example above.
 
 
 --
+
 
 == Ending notes
 
@@ -502,6 +510,6 @@ Happy authoring!
 
 == References
 
-* https://www.metanorma.com/author/topics/automation/yaml_to_text/[Generating
-  text from YAML data^]
+* https://www.metanorma.com/author/topics/automation/yaml_to_text/[Generating text from YAML data^]
 * https://yaml.org/[The Official YAML Web Site^]
+* link:/blog/2020-05-07-using-yaml-as-data-source[Using YAML as data source (original blog post)], 2020-05-07.

--- a/author/topics/automation/yaml_to_text.adoc
+++ b/author/topics/automation/yaml_to_text.adoc
@@ -27,7 +27,7 @@ See https://shopify.github.io/liquid/basics/introduction/[here] for the full des
 
 NOTE: Liquid expressions are supported from
 https://github.com/metanorma/metanorma-standoc/releases/tag/v1.5.3[metanorma-standoc version 1.5.3] onwards.
-See link:/blog/2020-09-20-using-yaml-as-data-source[this blog post] for more examples.
+See link:/blog/2020-09-20-yaml2text-supports-yaml-with-liquid[this blog post] for more examples.
 
 NOTE: Old form expressions were supported between
 https://github.com/metanorma/metanorma-standoc/releases/tag/v1.3.25[metanorma-standoc version 1.3.25] and

--- a/author/topics/automation/yaml_to_text.adoc
+++ b/author/topics/automation/yaml_to_text.adoc
@@ -61,14 +61,14 @@ Where:
 `yaml2text` accepts string interpolation of the following forms:
 
 . `{variable}`: as in AsciiDoc syntax;
-. `{{ variable }}`, `{% variable %}`: basic Liquid tags and expressions are supported.
+. `{{ variable }}`, `{% if/else/for/case %}`: basic Liquid tags and expressions are supported.
 
 The value within the curly braces will be interpolated by `yaml2text`.
 
 Where:
 
-* In `{variable}`, `variable` is the name of the variable or AsciiDoc attribute.
-* The location of `{variable}` in text will be replaced with the value of `variable`.
+* In `{variable}`(`{{variable}}`), `variable` is the name of the variable or AsciiDoc attribute.
+* The location of `{variable}`(`{{variable}}`) in text will be replaced with the value of `variable`.
 * Evaluation order will be first from the defined context, then of the Metanorma AsciiDoc document.
 
 
@@ -93,12 +93,12 @@ And the block:
 ------
 [yaml2text,strings.yaml,data]
 ----
-I'm heading to the {data.foo} for {data.dead}.
+I'm heading to the {{data.foo}} for {{data.dead}}.
 ----
 ------
 
 The file path is `strings.yaml`, and context name is `data`.
-`{data.foo}` evaluates to the value of the key `foo` in `data`.
+`{{data.foo}}` evaluates to the value of the key `foo` in `data`.
 
 Will render as:
 [source,asciidoc]
@@ -113,7 +113,7 @@ I'm heading to the bar for beef.
 
 ==== Length
 
-The length of an array can be obtained by `{arrayname.*}`.
+The length of an array can be obtained by `{{arrayname.size}}`.
 
 EXAMPLE:
 --
@@ -133,12 +133,12 @@ And the block:
 ------
 [yaml2text,strings.yaml,data]
 ----
-The length of the YAML array is {data.*}.
+The length of the YAML array is {{data.size}}.
 ----
 ------
 
 The file path is `strings.yaml`, and context name is `data`.
-`{data.*}` evaluates to the length of the array.
+`{{data.size}}` evaluates to the length of the array using liquid `size` https://shopify.github.io/liquid/filters/size/[filter].
 
 Will render as:
 [source,asciidoc]
@@ -154,24 +154,29 @@ The following syntax is used to enumerate items within an array:
 
 [source,asciidoc]
 --
-{array_name.*,item_name,block_delimiter}
+{% for item in array_name %}
   ...content...
-{block_delimiter}
+{% endfor %}
 --
 
 Where:
 
 * `array_name` is the name of the existing context that contains array data
-* `item_name` is used to refer to the current item within the array
-* `block_delimiter` indicates where the array enumeration block ends
+* `item` is the current item within the array
 
-Within an array enumerator, the following expressions can be used:
+Within an array enumerator, the following https://shopify.dev/docs/themes/liquid/reference/objects/for-loops[expressions] can be used:
 
-* `item_name.#` gives the zero-based position of the item `item_name` within the parent array
+* `{{forloop.index0}}` gives the zero-based position of the item `item_name` within the parent array
 
-* `array_name.*` gives the length of the array `array_name`
+* `{{forloop.length}}` returns the number of iterations of the loop.
 
-* `array_name[i]` provides the value at index `i` (zero-based: starts with `0`) in the array `array_name`; `-1` can be used to refer to the last item, `-2` the second last item, and so on.
+* `{{forloop.first}}` returns `true` if it's the first iteration of the for loop. Returns `false` if it is not the first iteration.
+
+* `{{forloop.last}}` returns `true` if it's the last iteration of the for loop. Returns `false` if it is not the last iteration.
+
+* `{{array_name.size}}` gives the length of the array `array_name`
+
+* `{{array_name[i]}}` provides the value at index `i` (zero-based: starts with `0`) in the array `array_name`; `-1` can be used to refer to the last item, `-2` the second last item, and so on.
 
 
 EXAMPLE:
@@ -192,12 +197,12 @@ And the block:
 ------
 [yaml2text,strings.yaml,arr]
 ----
-{arr.*,item,EOS}
-=== {item.#} {item}
+{% for item in arr %}
+=== {{forloop.index0}} {item}
 
 This section is about {item}.
 
-{EOS}
+{endfor}
 ----
 ------
 
@@ -205,7 +210,7 @@ Where:
 
 * file path is `strings.yaml`
 * current context within the enumerator is called `item`
-* `{item.#}` gives the zero-based position of item `item` in the parent array `arr`.
+* `{{forloop.index0}}` gives the zero-based position of item `item` in the parent array `arr`.
 
 Will render as:
 [source,text]
@@ -233,7 +238,7 @@ This section is about dolor.
 ==== Size
 
 Similar to arrays, the number of key-value pairs within an object can be
-obtained by `{objectname.*}`.
+obtained by `{{objectname.size}}`.
 
 EXAMPLE:
 --
@@ -252,14 +257,14 @@ And the block:
 ------
 [yaml2text,object.yaml,data]
 ----
-=== {data.name}
+=== {{data.name}}
 
-{data.desc}
+{{data.desc}}
 ----
 ------
 
 The file path is `object.yaml`, and context name is `data`.
-`{data.*}` evaluates to the size of the object.
+`{{data.size}}` evaluates to the size of the object.
 
 Will render as:
 [source,asciidoc]
@@ -277,21 +282,17 @@ The following syntax is used to enumerate key-value pairs within an object:
 
 [source,asciidoc]
 --
-{object_name.*,key_name,block_delimiter}
-  ...content...
-{block_delimiter}
+{% for item in object_name %}
+  {{item[0]}}, {{item[1]}}
+{% endfor %}
 --
 
 Where:
 
 * `object_name` is the name of the existing context that contains the object
-* `key_name` is used to refer to the current key under enumeration within the object
-* `block_delimiter` indicates where the object enumeration block ends
-
-Within an object enumerator, the following expressions can be used:
-
-* `item_name[key]` gives the dereferenced value of the data path `item_name.{key}. e.g. `{yaml.items[s.#]}`, `{my_object[key_name]}`. Note that items should only be de-referenced with the item key, not with an integer index.
-
+* `{{item[0]}}` contains the key of the current enumrated object
+* `{{item[1]}}` contains the value
+* `{% endfor %}` indicates where the object enumeration block ends
 
 
 EXAMPLE:
@@ -311,20 +312,21 @@ And the block:
 ------
 [yaml2text,object.yaml,my_item]
 ----
-{my_item.*,key,EOI}
-=== {key}
+{% for item in my_item %}
+=== {{item[0]}}
 
-{my_item[key]}
+{{item[1]}}
 
-{EOI}
+{% endfor %}
 ----
 ------
 
 Where:
 
 * file path is `object.yaml`
-* current key within the enumerator is called `key`
-* `{my_item[key]}` gives the value of key `key` in the parent array `my_item`.
+* current key within the enumerator is called `item[0]`
+* `{{item[0]}}` gives the key name in the current iteration
+* `{{item[1]}}` gives the value in the current iteration
 
 Will render as:
 [source,text]
@@ -362,13 +364,13 @@ And the block:
 ------
 [yaml2text,object.yaml,item]
 ----
-.{item.values[1]}
+.{{item.values[1]}}
 [%noheader,cols="h,1"]
 |===
-{item.*,key,EOK}
-| {key} | {item[key]}
+{% for elem in item %}
+| {{elem[0]}} | {{elem[1]}}
 
-{EOK}
+{% endfor %}
 |===
 ----
 ------
@@ -377,8 +379,8 @@ Where:
 
 * file path is `object.yaml`
 * current key within the enumerator is called `key`
-* `{item[key]}` gives the value of key `key` in the parent array `item`
-* `item.values[1]` gives the value located at the second key within `item`
+* `{{item[1]}}` gives the value of key in the current iteration the parent array `my_item`.
+* `{{item.values[1]}}` gives the value located at the second key within `item`
 
 Will render as:
 [source,text]
@@ -390,6 +392,53 @@ Will render as:
 | name | Lorem ipsum
 | desc | dolor sit amet
 |===
+----
+
+--
+
+There are several optional arguments to the for tag that can influence which items you receive in your loop and what order they appear in:
+
+* limit:<INTEGER> lets you restrict how many items you get.
+* offset:<INTEGER> lets you start the collection with the nth item.
+* reversed iterates over the collection from last to first.
+
+EXAMPLE:
+--
+Given:
+
+strings.yaml
+[source,yaml]
+----
+---
+- lorem
+- ipsum
+- dolor
+- sit
+- amet
+----
+
+And the block:
+[source,asciidoc]
+------
+[yaml2text,strings.yaml,items]
+----
+{% for elem in items limit:2 offset:2 %}
+{{item}}
+{% endfor %}
+----
+------
+
+Where:
+
+* file path is `strings.yaml`
+* `limit` - how many items we shoudl take from the array
+* `offset` - zero-based offset of item from which start the loop
+* `{{item}}` gives the value of item in the array
+
+Will render as:
+[source,text]
+----
+dolor sit
 ----
 
 --
@@ -428,22 +477,21 @@ And the block:
 ------
 [yaml2text,array_of_objects.yaml,ar]
 ----
-{ar.*,item,EOF}
+{% for item in ar %}
 
-{item.name}:: {item.desc}
+{{item.name}}:: {{item.desc}}
 
-{item.nums.*,num,EON}
-- {item.name}: {num}
-{EON}
+{% for num in item.nums %}
+- {{item.name}}: {{num}}
+{% endfor %}
 
-{EOF}
+{% endfor %}
 ----
 ------
 
 Notice we are now defining multiple contexts:
 
 * using different context names: `ar`, `item`, and `num`
-* delimited by different block markers: `EOF, EON` (self-defined, heredoc-esque markers)
 
 Will render as:
 [source,asciidoc]
@@ -488,18 +536,18 @@ And the block:
 --------
 [yaml2text,strings.yaml,yaml]
 ------
-First item is {yaml.items[0]}.
-Last item is {yaml.items[-1]}.
+First item is {{yaml.items.first}}.
+Last item is {{yaml.items.last}}.
 
-{yaml.items.*,s,EOS}
-=== {s.#} -> {s.# + 1} {s} == {yaml.items[s.#]}
+{% for s in yaml.items %}
+=== {{forloop.index0}} -> {{forloop.index0 | plus: 1}} {{s}} == {{yaml.items[forloop.index0]}}
 
 [source,ruby]
 ----
-\include::{yaml.prefix}{s.#}.rb[]
+\include::{{yaml.prefix}}{{forloop.index0}}.rb[]
 ----
 
-{EOS}
+{% endfor %}
 ------
 --------
 
@@ -531,50 +579,6 @@ Last item is dolor.
 \include::doc-2.rb[]
 ----
 
-------
-
---
-
-
-=== Liquid code snippets
-
-`yaml2text` can use basic Liquid expressions and tags. Yaml data is stored in the <<defining_syntax,context name>> variable which can be used in the expressions.
-
-EXAMPLE:
---
-Given:
-
-example.yml
-[source,yaml]
-----
----
-- name: One
-  show: true
-- name: Two
-  show: true
-- name: Three
-  show: false
-----
-
-And the block:
-[source,asciidoc]
---------
-[yaml2text,example.yml,my_context]
-----
-{% for item in my_context %}
-{% if item.show %}
-{{ item.name | upcase }}
-{{ item.name | size }}
-{% endif %}
-{% endfor %}
-----
---------
-
-Will render as:
-[source,asciidoc]
-------
-ONE 3
-TWO 3
 ------
 
 --

--- a/author/topics/automation/yaml_to_text.adoc
+++ b/author/topics/automation/yaml_to_text.adoc
@@ -27,7 +27,12 @@ See https://shopify.github.io/liquid/basics/introduction/[here] for the full des
 
 NOTE: Liquid expressions are supported from
 https://github.com/metanorma/metanorma-standoc/releases/tag/v1.5.3[metanorma-standoc version 1.5.3] onwards.
+See link:/blog/2020-09-20-using-yaml-as-data-source[this blog post] for more examples.
 
+NOTE: Old form expressions were supported between
+https://github.com/metanorma/metanorma-standoc/releases/tag/v1.3.25[metanorma-standoc version 1.3.25] and
+https://github.com/metanorma/metanorma-standoc/releases/tag/v1.5.3[version 1.5.3].
+See link:/blog/2020-05-07-using-yaml-as-data-source[the original blog post] for more examples.
 
 
 == Syntax

--- a/author/topics/automation/yaml_to_text.adoc
+++ b/author/topics/automation/yaml_to_text.adoc
@@ -16,7 +16,7 @@ from a separate YAML file into the document. [added in https://github.com/metano
 
 == Expressions
 
-There are only two kinds of expressions:
+Before (metanorma-standoc 1.5.3 release)[https://github.com/metanorma/metanorma-standoc/releases/tag/v1.5.3] there were only two kinds of expressions:
 
 * rendering expressions: for string interpolation (single argument, e.g. `{x}`)
 * control flow expressions: for directives to modify processing flow (more than one argument, e.g. `{x,y}`)
@@ -39,10 +39,18 @@ Control flow expressions:
 * Allows control over enumerable items: arrays and objects
 * Provides locality context within enumerators
 
+In https://github.com/metanorma/metanorma-standoc/releases/tag/v1.5.3[metanorma-standoc 1.5.3 release] support for liquid expressions was added. yaml2text now supports all liquid default https://shopify.github.io/liquid/basics/introduction/[syntax] expressions:
 
+* variables, variable assignment
+* flow control(if/case)
+* filters
+* loops
+
+See https://shopify.github.io/liquid/basics/introduction/ for the full description of liquid tags and expressions.
 
 == Syntax
 
+[[defining_syntax]]
 === Defining the block
 
 A `yaml2text` block is created with the following syntax.
@@ -68,7 +76,7 @@ Where:
 
 === Interpolation
 
-`yaml2text` takes an interpolation syntax that is similar to that of AsciiDoc with curly braces `{ }`.
+`yaml2text` takes an interpolation syntax that is similar to that of AsciiDoc with curly braces `{ }`, also basic liquid tags and expressions are supported: `{{ }}`, `{% %}`
 
 The value within the curly braces will be interpolated by `yaml2text`.
 
@@ -536,6 +544,50 @@ Last item is dolor.
 \include::doc-2.rb[]
 ----
 
+------
+
+--
+
+
+=== Liquid code snippets
+
+`yaml2text` can use basic Liquid expressions and tags. Yaml data is stored in the <<defining_syntax,context name>> variable which can be used in the expressions.
+
+EXAMPLE:
+--
+Given:
+
+example.yml
+[source,yaml]
+----
+---
+- name: One
+  show: true
+- name: Two
+  show: true
+- name: Three
+  show: false
+----
+
+And the block:
+[source,asciidoc]
+--------
+[yaml2text,example.yml,my_context]
+----
+{% for item in my_context %}
+{% if item.show %}
+{{ item.name | upcase }}
+{{ item.name | size }}
+{% endif %}
+{% endfor %}
+----
+--------
+
+Will render as:
+[source,asciidoc]
+------
+ONE 3
+TWO 3
 ------
 
 --


### PR DESCRIPTION
    metanorma/metanorma-standoc#327, #331 documentation for yaml2text liquid support. @opoudjis @ronaldtse i have mentioned metnorma-standoc new version as 1.5.3, fell free to change it for the actual one after the release.